### PR TITLE
feat!: add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Terraform module to manage an AWS Security Group.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of the security group. | `string` | `null` | no |
 | <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | Security group egress rules. | <pre>map(object({<br/>    cidr_ipv4                    = optional(list(string))<br/>    cidr_ipv6                    = optional(list(string))<br/>    description                  = string<br/>    from_port                    = optional(number)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number)<br/>  }))</pre> | `{}` | no |
 | <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | Security group ingress rules. | <pre>map(object({<br/>    cidr_ipv4                    = optional(list(string))<br/>    cidr_ipv6                    = optional(list(string))<br/>    description                  = string<br/>    from_port                    = optional(number)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number)<br/>  }))</pre> | `{}` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_revoke_rules_on_delete"></a> [revoke\_rules\_on\_delete](#input\_revoke\_rules\_on\_delete) | Instruct Terraform to revoke all of the security group attached ingress and egress rules before deleting the group itself. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign on all resources. | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define custom maximum timeout for creating and deleting the security group. | <pre>object({<br/>    create = optional(string, "10m")<br/>    delete = optional(string, "15m")<br/>  })</pre> | `{}` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v3.0.0
+
+### Key Changes v3.0.0
+
+This module now requires a minimum AWS provider version of 6.0 to support the region parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
+
 ## Upgrading to v2.0.0
 
 ### Key Changes

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/security-group-id/terraform.tf
+++ b/examples/security-group-id/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ locals {
 resource "aws_security_group" "default" {
   #checkov:skip=CKV2_AWS_5: "Ensure that Security Groups are attached to another resource" - False positive.
 
+  region                 = var.region
   description            = var.description
   name_prefix            = var.name_prefix
   revoke_rules_on_delete = var.revoke_rules_on_delete
@@ -78,6 +79,7 @@ resource "aws_security_group" "default" {
 resource "aws_vpc_security_group_egress_rule" "default" {
   for_each = local.egress_rules
 
+  region                       = var.region
   cidr_ipv4                    = each.value.cidr_ipv4
   cidr_ipv6                    = each.value.cidr_ipv6
   description                  = each.value.description
@@ -93,6 +95,7 @@ resource "aws_vpc_security_group_egress_rule" "default" {
 resource "aws_vpc_security_group_ingress_rule" "default" {
   for_each = local.ingress_rules
 
+  region                       = var.region
   cidr_ipv4                    = each.value.cidr_ipv4
   cidr_ipv6                    = each.value.cidr_ipv6
   description                  = each.value.description

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "name_prefix" {
   description = "Name prefix of the security group."
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "revoke_rules_on_delete" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR updates the required AWS Provider version to v6.0 and introduces region parameter to allow defining region where the module resources will be deployed without requiring a separate provider configuration.